### PR TITLE
README.md FAQ: Explain FOV and "best" altitude

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ For licensing information, please see the [included LICENSE.txt][SCANsat:rel-lic
     * **No!** This version is completely backwards compatible, and you current scanning state (which is stored in persistent.sfs) will be safe and sound. Nevertheless, you should make a backup copy of your game before upgading any mod.
   * Do I need to attach a part to my vessel to use SCANsat?
     * **No, but...**. You can view existing maps from any vessel, but you need to attach a scanner to add new data to the maps.
+  * What does the "field of view" mean?
+    * When a sensor is at or above its "best" altitude (but below its maximum altitude) the field of view is the width of the swath mapped by the instrument, if it were in orbit around Kerbin. In other words, a field of view of 10° would map swathes which are 1/36th of the planetary surface wide. Larger and smaller bodies would take longer or shorter times to map, respectively.
+  * What does the "best" altitude mean?
+    * At or above the best altitude, the sensor will operate with its listed field of view. Below this altitude the sensor suffers a linear penalty. A 10° FOV instrument with a best altitude of 500km would only have a 5° FOV at 250km.
   * [Career Mode] Does SCANsat give us science points?
     * **Yes!** For each type of map, if you scan at least 30% of the surface, you can yse Data for partial science points; up until the maximum value at 95% map coverage.
   * [Career Mode] Is it integrated into the tech tree?


### PR DESCRIPTION
This is based upon my best understanding by reading `SCANcontroller.doScanPass()`. At first I thought that FOV was a virtual cone drawn underneath the instrument to the surface, but the main sensor loop seems to just walk lat/long from -FOV to +FOV and register the scans with `SCANUtil.registerPass()`, with there being a linear penalty for being below the "best" altitude.

As an aside, walking from -FOV to +FOV means it would appear the actual width of the swathes is _twice_ the FOV; in other words, a 5° FOV results in swathes which are 10° (1/36th Kerbin) in size. However my understanding there might be off, as this is my first time looking at the SCANsat code.

In any case, this PR answers what the "best" altitude means and how FOV are calculated, which are frequently asked questions if you're me. :)
