### PR TITLE
Fixed P3 body issue with Contracts

### DIFF
--- a/SCANassets/Resources/Contracts/ContractPackScanSatOfficial.cfg
+++ b/SCANassets/Resources/Contracts/ContractPackScanSatOfficial.cfg
@@ -10,7 +10,7 @@ CONTRACT_GROUP
 	DATA
 	{
 		type = List<CelestialBody>
-		
+		requiredValue = false
 		p1Bodies = AllBodies().Where(cb => ((cb.IsHomeWorld() || cb.Parent().IsHomeWorld()) && cb.HasSurface()))
 		p2Bodies = OrbitedBodies().Where(cb => cb.HasSurface())
 		p3Bodies = ReachedBodies().Where(cb => cb.HasSurface() && cb != HomeWorld() && cb.Parent() != HomeWorld())


### PR DESCRIPTION
For some reason, contracts will not generate if the player has not been outside Kerbin/Mun/Minmus.

The problem seems to be with the p3 bodies - it's looking for bodies the player has reached, which aren't the homeworld or it's moons. If the player hasn't left Kerbins SOI then this returns null. I had to turn on CC Verbose logging, but I caught a "SCAN_LoRes failed to generate as p3bodies count is zero"

I don't fully understand why this isn't generating LoRes contracts at least, because SCAN_LoRes doesn't look for p3, but I assume it's because they are all defined in the same DATA node.

Anyway, this fixes it. I just put a "requiredValue = false" flag on the list. The contracts still require a value, but they won't fall over because not all the lists have been populated (they should just ignore empty lists).
