### PR TITLE
Fix case of SCANbigMap.cs in SCANsat.csproj

### DIFF
--- a/SCANsat/SCANsat.csproj
+++ b/SCANsat/SCANsat.csproj
@@ -96,7 +96,7 @@
     <Compile Include="SCAN_Toolbar\SCANtoolbar.cs" />
     <Compile Include="SCAN_Toolbar\SCANtoolbarwrapper.cs" />
     <Compile Include="SCAN_UI\SCANcolorSelection.cs" />
-    <Compile Include="SCAN_UI\SCANBigMap.cs" />
+    <Compile Include="SCAN_UI\SCANbigMap.cs" />
     <Compile Include="SCAN_UI\SCANoverlayController.cs" />
     <Compile Include="SCAN_UI\SCANresourceSettings.cs" />
     <Compile Include="SCAN_UI\SCANzoomHiDef.cs" />


### PR DESCRIPTION
This has no effect on Windows, which has a case-insensitive file system, but fixes a build error for Mono builds on Linux (which are case-sensitive).
