### PR TITLE
prevent InvalidOperationException from toolbar

### DIFF
--- a/SCANsat/SCAN_Toolbar/SCANtoolbarwrapper.cs
+++ b/SCANsat/SCAN_Toolbar/SCANtoolbarwrapper.cs
@@ -728,9 +728,16 @@ namespace SCANsat.SCAN_Toolbar {
 		}
 
 		internal static Type getType(string name) {
-			return AssemblyLoader.loadedAssemblies
-				.SelectMany(a => a.assembly.GetExportedTypes())
-				.SingleOrDefault(t => t.FullName == name);
+			foreach (AssemblyLoader.LoadedAssembly assembly in AssemblyLoader.loadedAssemblies) {
+				try {
+					var type = assembly.assembly.GetExportedTypes().SingleOrDefault(t => t.FullName == name);
+					if (type != null) {
+						return type;
+					}
+				} catch (InvalidOperationException) {
+				}
+			}
+			return null;
 		}
 
 		internal static PropertyInfo getProperty(Type type, string name) {


### PR DESCRIPTION
Modify `ToolbarTypes.getType()` in `SCANtoolbarwrapper.cs` .
