### PR TITLE
Do not open multiple Big Map windows (fixes #261)

### DIFF
--- a/SCANsat/SCAN_Toolbar/SCANappLauncher.cs
+++ b/SCANsat/SCAN_Toolbar/SCANappLauncher.cs
@@ -302,7 +302,8 @@ namespace SCANsat.SCAN_Toolbar
 			set
 			{
 				if (value)
-					SCAN_UI_BigMap.Instance.Open();
+					if (!SCAN_UI_BigMap.Instance.IsVisible)
+						SCAN_UI_BigMap.Instance.Open();
 				else
 					SCAN_UI_BigMap.Instance.Close();
 			}


### PR DESCRIPTION
Check if the Big Map window is visible before trying to open/reopen it by clicking on the toolbar button