### PR TITLE
Fixed a mistake of Chinese translation

### DIFF
--- a/SCANassets/Resources/Localization/OtherText.cfg
+++ b/SCANassets/Resources/Localization/OtherText.cfg
@@ -114,7 +114,7 @@
 		#autoLOC_SCANsat_MapResource = 资源
 		#autoLOC_SCANsat_MapBody = 天体
  		#autoLOC_SCANsat_GeneralSettings = 全局设置
- 		#autoLOC_SCANsat_BackgroundSettings = 背景设置
+ 		#autoLOC_SCANsat_BackgroundSettings = 后台设置
  		#autoLOC_SCANsat_ResourceSettings = 资源设置
  		#autoLOC_SCANsat_DataManagement = 数据管理
  		#autoLOC_SCANsat_ColorManagement = 颜色管理


### PR DESCRIPTION
"background" has two meanings in Chinese and I used the wrong one. I fixed it.