### PR TITLE
SCANsat and ModuleSCANresourceScanner VAB/SPH info update

### DIFF
--- a/SCANassets/Resources/Localization/en-us/OtherText.cfg
+++ b/SCANassets/Resources/Localization/en-us/OtherText.cfg
@@ -18,10 +18,10 @@
 		#autoLOC_SCANsat_NoData			= No Data
 		#autoLOC_SCANsat_Abundance		= Abundance
 		#autoLOC_SCANsat_Surface		= Surf
-		#autoLOC_SCANsat_AltitudeMin		= Altitude ( min): <<1>>km\n
+		#autoLOC_SCANsat_AltitudeMin		= Altitude (min): <<1>>km\n
 		#autoLOC_SCANsat_AltitudeBest		= Altitude (best): <<1>>km\n
-		#autoLOC_SCANsat_AltitudeMax		= Altitude ( max): <<1>>km\n
-		#autoLOC_SCANsat_FOV			= FOV: <<1>>
+		#autoLOC_SCANsat_AltitudeMax		= Altitude (max): <<1>>km\n
+		#autoLOC_SCANsat_FOV			= Field of view: <<1>>\n
 		#autoLOC_SCANsat_MapProjection		= Projection
 		#autoLOC_SCANsat_MapType		= Map Type
 		#autoLOC_SCANsat_MapResource		= Resource

--- a/SCANsat/SCAN_PartModules/SCANresourceScanner.cs
+++ b/SCANsat/SCAN_PartModules/SCANresourceScanner.cs
@@ -51,12 +51,19 @@ namespace SCANsat.SCAN_PartModules
 			refreshState = true;
 		}
 
+		protected string FormatResourceScanTypeInfo()
+		{
+			return "Resource Scan: " + (SCANtype)sensorType + "\n";
+		}
+
 		public override string GetInfo()
 		{
-			string info = base.GetInfo();
-			info += "Resource Scan: " + (SCANtype)sensorType + "\n";
-
-			return info;
+			string str = "";
+			str += FormatAltitudeInfo();
+			str += FormatScanTypeInfo();
+			str += FormatResourceScanTypeInfo();
+			str += resHandler.PrintModuleResources(1);
+			return str;
 		}
 
 		private List<ModuleOrbitalScanner> findScanner()

--- a/SCANsat/SCAN_PartModules/SCANsat.cs
+++ b/SCANsat/SCAN_PartModules/SCANsat.cs
@@ -174,12 +174,10 @@ namespace SCANsat.SCAN_PartModules
 			}
 		}
 
-		public override string GetInfo()
+		// Return formatted altitude information for GetInfo()
+		protected string FormatAltitudeInfo()
 		{
-			if (sensorType == 0)
-				return "";
-
-			string str = base.GetInfo();
+			string str = "";
 			if (min_alt != 0)
 				str += Localizer.Format("#autoLOC_SCANsat_AltitudeMin", (min_alt / 1000).ToString("F0"));
 			if (best_alt != min_alt)
@@ -188,7 +186,24 @@ namespace SCANsat.SCAN_PartModules
 				str += Localizer.Format("#autoLOC_SCANsat_AltitudeMax", (max_alt / 1000).ToString("F0"));
 			if (fov != 0)
 				str += Localizer.Format("#autoLOC_SCANsat_FOV", fov.ToString("F0") + "°");
+			return str;
+		}
 
+
+		// Return formatted scan type information for GetInfo()
+		protected string FormatScanTypeInfo()
+		{
+			return "Scan type: " + scanName + "\n";
+		}
+
+		public override string GetInfo()
+		{
+			if (sensorType == 0)
+				return "";
+
+			string str = "";
+			str += FormatAltitudeInfo();
+			str += FormatScanTypeInfo();
 			str += resHandler.PrintModuleResources(1);
 			return str;
 		}


### PR DESCRIPTION
Some part packs integrate SCANsat support but part description are not always clear about which scan the part can conduct.

So this PR add the Scan type (Radar, SAR, multi, ...) of the module into the part description.

I added dedicated function for altitude, scan type and scan resource type details. This would avoid the need to redo the logic for the presentation if someone want to inherit from theses modules.
I also used this to move the EC consumption at the end of the description of the ModuleSCANresourceScanner module.

I also updated the english localization. I added the line feed to FOV to be consistent with altitudes. Other change are just personal taste.