### PR TITLE
Fix Chinese locale names

### DIFF
--- a/SCANassets/Resources/Localization/zh-cn/Parts.cfg
+++ b/SCANassets/Resources/Localization/zh-cn/Parts.cfg
@@ -1,6 +1,6 @@
 ﻿Localization
 {
-	zh-ch
+	zh-cn
 	{
 		#autoLOC_SCANsat_BTDT_Title			= SCAN Been There Done That®
 		#autoLOC_SCANsat_BTDT_Description		= 这个小的传感器能自动识别附近的异常，就算它只在非常短的距离内和非常低的高度上工作，可用于跟踪已识别的异常点，非常有用。

--- a/SCANassets/Resources/Localization/zh-cn/Science.cfg
+++ b/SCANassets/Resources/Localization/zh-cn/Science.cfg
@@ -1,6 +1,6 @@
 ﻿Localization
 {
-	zh-ch
+	zh-cn
 	{
 		#autoLOC_SCANsat_Science_Lo_Title		= 低精度高度扫描
 		#autoLOC_SCANsat_Science_Lo_Default1		= 分析低精度高度数据。


### PR DESCRIPTION
Two of this mod's localization files have "zh-c**h**" instead of "zh-c**n**". This probably means that those strings are not being used in-game when the locale is set to Chinese.
This pull request fixes them.