### PR TITLE
Fix "ADDON BINDER: Cannot resolve assembly" errors in log

### DIFF
--- a/SCANsat.Unity/HSVPicker/Enums/ColorValues.cs
+++ b/SCANsat.Unity/HSVPicker/Enums/ColorValues.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace SCANsat.Unity.HSVPicker.Enum
+namespace SCANsat.Unity.HSVPicker
 {
 	public enum ColorValues
 	{

--- a/SCANsat.Unity/HSVPicker/Events/ColorChangedEvent.cs
+++ b/SCANsat.Unity/HSVPicker/Events/ColorChangedEvent.cs
@@ -2,7 +2,7 @@
 using System;
 using UnityEngine.Events;
 
-namespace SCANsat.Unity.HSVPicker.Events
+namespace SCANsat.Unity.HSVPicker
 {
 	[Serializable]
 	public class ColorChangedEvent : UnityEvent<Color>

--- a/SCANsat.Unity/HSVPicker/Events/HSVChangedEvent.cs
+++ b/SCANsat.Unity/HSVPicker/Events/HSVChangedEvent.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEngine;
 using UnityEngine.Events;
 
-namespace SCANsat.Unity.HSVPicker.Events
+namespace SCANsat.Unity.HSVPicker
 {
 	public class HSVChangedEvent : UnityEvent<float, float, float>
 	{

--- a/SCANsat.Unity/HSVPicker/UI/ColorImage.cs
+++ b/SCANsat.Unity/HSVPicker/UI/ColorImage.cs
@@ -2,7 +2,7 @@
 using UnityEngine.UI;
 using System.Collections;
 
-namespace SCANsat.Unity.HSVPicker.UI
+namespace SCANsat.Unity.HSVPicker
 {
 	[RequireComponent(typeof(Image))]
 	public class ColorImage : MonoBehaviour

--- a/SCANsat.Unity/HSVPicker/UI/ColorInput.cs
+++ b/SCANsat.Unity/HSVPicker/UI/ColorInput.cs
@@ -1,9 +1,8 @@
 ﻿using UnityEngine;
 using UnityEngine.UI;
 using System;
-using SCANsat.Unity.HSVPicker.Enum;
 
-namespace SCANsat.Unity.HSVPicker.UI
+namespace SCANsat.Unity.HSVPicker
 {
 	/// <summary>
 	/// Displays one of the color values of aColorPicker

--- a/SCANsat.Unity/HSVPicker/UI/ColorLabel.cs
+++ b/SCANsat.Unity/HSVPicker/UI/ColorLabel.cs
@@ -1,9 +1,8 @@
 ﻿using UnityEngine;
 using UnityEngine.UI;
 using System;
-using SCANsat.Unity.HSVPicker.Enum;
 
-namespace SCANsat.Unity.HSVPicker.UI
+namespace SCANsat.Unity.HSVPicker
 {
 	[RequireComponent(typeof(TextHandler))]
 	public class ColorLabel : MonoBehaviour

--- a/SCANsat.Unity/HSVPicker/UI/ColorPicker.cs
+++ b/SCANsat.Unity/HSVPicker/UI/ColorPicker.cs
@@ -2,11 +2,8 @@
 using System.Collections;
 using UnityEngine.UI;
 using UnityEngine.Events;
-using SCANsat.Unity.HSVPicker.Utility;
-using SCANsat.Unity.HSVPicker.Enum;
-using SCANsat.Unity.HSVPicker.Events;
 
-namespace SCANsat.Unity.HSVPicker.UI
+namespace SCANsat.Unity.HSVPicker
 {
 	public class ColorPicker : MonoBehaviour
 	{

--- a/SCANsat.Unity/HSVPicker/UI/ColorSlider.cs
+++ b/SCANsat.Unity/HSVPicker/UI/ColorSlider.cs
@@ -1,9 +1,8 @@
 ﻿using UnityEngine;
 using UnityEngine.UI;
 using System;
-using SCANsat.Unity.HSVPicker.Enum;
 
-namespace SCANsat.Unity.HSVPicker.UI
+namespace SCANsat.Unity.HSVPicker
 {
 	/// <summary>
 	/// Displays one of the color values of aColorPicker

--- a/SCANsat.Unity/HSVPicker/UI/ColorSliderImage.cs
+++ b/SCANsat.Unity/HSVPicker/UI/ColorSliderImage.cs
@@ -1,10 +1,8 @@
 ﻿using UnityEngine;
 using UnityEngine.UI;
 using System.Collections;
-using SCANsat.Unity.HSVPicker.Enum;
-using SCANsat.Unity.HSVPicker.Utility;
 
-namespace SCANsat.Unity.HSVPicker.UI
+namespace SCANsat.Unity.HSVPicker
 {
 	[RequireComponent(typeof(RawImage)), ExecuteInEditMode()]
 	public class ColorSliderImage : MonoBehaviour

--- a/SCANsat.Unity/HSVPicker/UI/SVBoxSlider.cs
+++ b/SCANsat.Unity/HSVPicker/UI/SVBoxSlider.cs
@@ -1,10 +1,8 @@
 ﻿using UnityEngine;
 using UnityEngine.UI;
 using System.Collections;
-using SCANsat.Unity.HSVPicker.Utility;
-using SCANsat.Unity.HSVPicker.Enum;
 
-namespace SCANsat.Unity.HSVPicker.UI
+namespace SCANsat.Unity.HSVPicker
 {
 	[RequireComponent(typeof(BoxSlider), typeof(RawImage)), ExecuteInEditMode()]
 	public class SVBoxSlider : MonoBehaviour

--- a/SCANsat.Unity/HSVPicker/UtilityScripts/BoxSlider.cs
+++ b/SCANsat.Unity/HSVPicker/UtilityScripts/BoxSlider.cs
@@ -4,7 +4,7 @@ using UnityEngine.UI;
 using UnityEngine.Events;
 using UnityEngine.EventSystems;
 
-namespace SCANsat.Unity.HSVPicker.Utility
+namespace SCANsat.Unity.HSVPicker
 {
 	[AddComponentMenu("UI/BoxSlider", 35)]
 	[RequireComponent(typeof(RectTransform))]

--- a/SCANsat.Unity/HSVPicker/UtilityScripts/HSVUtil.cs
+++ b/SCANsat.Unity/HSVPicker/UtilityScripts/HSVUtil.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System;
 
-namespace SCANsat.Unity.HSVPicker.Utility
+namespace SCANsat.Unity.HSVPicker
 {
 	#region ColorUtilities
 

--- a/SCANsat.Unity/Properties/AssemblyInfo.cs
+++ b/SCANsat.Unity/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -24,3 +24,5 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("1.8.14.0")]
 [assembly: AssemblyFileVersion("1.8.14.0")]
+
+[assembly: KSPAssembly("SCANsat.Unity", 1, 0)]

--- a/SCANsat.Unity/SCAN_ColorPicker.cs
+++ b/SCANsat.Unity/SCAN_ColorPicker.cs
@@ -15,16 +15,15 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
-using SCANsat.Unity.HSVPicker.UI;
 
 namespace SCANsat.Unity
 {
 	public class SCAN_ColorPicker : MonoBehaviour
 	{
 		[SerializeField]
-		private ColorImage m_ColorOne = null;
+		private HSVPicker.ColorImage m_ColorOne = null;
 		[SerializeField]
-		private ColorImage m_ColorTwo = null;
+		private HSVPicker.ColorImage m_ColorTwo = null;
 		[SerializeField]
 		private Image m_OldColorOne = null;
 		[SerializeField]
@@ -36,7 +35,7 @@ namespace SCANsat.Unity
 		[SerializeField]
 		private InputHandler m_BInputField = null;
 
-		private ColorPicker picker;
+		private HSVPicker.ColorPicker picker;
 
 		private bool anyInputActive;
 
@@ -57,7 +56,7 @@ namespace SCANsat.Unity
 
 		private void Awake()
 		{
-			picker = GetComponent<ColorPicker>();
+			picker = GetComponent<HSVPicker.ColorPicker>();
 		}
 
 		private void Update()

--- a/SCANsat.Unity/SCANsat.Unity.csproj
+++ b/SCANsat.Unity/SCANsat.Unity.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>$(KSP_DIR)\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/SCANsat.Unity/SCANsat.Unity.csproj
+++ b/SCANsat.Unity/SCANsat.Unity.csproj
@@ -33,6 +33,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>$(KSP_DIR)\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="UnityEngine">
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.dll</HintPath>

--- a/SCANsat.Unity/Unity/SCAN_ColorAltimetry.cs
+++ b/SCANsat.Unity/Unity/SCAN_ColorAltimetry.cs
@@ -18,7 +18,6 @@ using UnityEngine.UI;
 using UnityEngine.Events;
 using UnityEngine.EventSystems;
 using SCANsat.Unity.Interfaces;
-using SCANsat.Unity.HSVPicker.UI;
 
 namespace SCANsat.Unity.Unity
 {

--- a/SCANsat.Unity/Unity/SCAN_ColorBiome.cs
+++ b/SCANsat.Unity/Unity/SCAN_ColorBiome.cs
@@ -18,7 +18,6 @@ using UnityEngine.UI;
 using UnityEngine.Events;
 using UnityEngine.EventSystems;
 using SCANsat.Unity.Interfaces;
-using SCANsat.Unity.HSVPicker.UI;
 
 namespace SCANsat.Unity.Unity
 {

--- a/SCANsat.Unity/Unity/SCAN_ColorResource.cs
+++ b/SCANsat.Unity/Unity/SCAN_ColorResource.cs
@@ -18,7 +18,6 @@ using UnityEngine.UI;
 using UnityEngine.Events;
 using UnityEngine.EventSystems;
 using SCANsat.Unity.Interfaces;
-using SCANsat.Unity.HSVPicker.UI;
 
 namespace SCANsat.Unity.Unity
 {

--- a/SCANsat.Unity/Unity/SCAN_ColorSlope.cs
+++ b/SCANsat.Unity/Unity/SCAN_ColorSlope.cs
@@ -18,7 +18,6 @@ using UnityEngine.UI;
 using UnityEngine.Events;
 using UnityEngine.EventSystems;
 using SCANsat.Unity.Interfaces;
-using SCANsat.Unity.HSVPicker.UI;
 
 namespace SCANsat.Unity.Unity
 {

--- a/SCANsat/Properties/AssemblyInfo.cs
+++ b/SCANsat/Properties/AssemblyInfo.cs
@@ -19,5 +19,4 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyInformationalVersion ("v18.14")]
 
 [assembly: KSPAssembly ("SCANsat", 1, 8)]
-
-
+[assembly: KSPAssemblyDependency("SCANsat.Unity", 1, 0)]


### PR DESCRIPTION
Fixes #355 by adding KSPAssembly and KSPAssemblyDependency stanzas to SCANsat and SCANsat.Unity projects respectively.

The latter requires adding a new Assembly Reference to Assembly-CSharp, which then requires fixing up some Namespace issues in the HSVPicker classes.