### PR TITLE
Changed instantiator into an Awake because of the following error which

### DIFF
--- a/SCANsat/SCAN_Toolbar/SCANtoolbar.cs
+++ b/SCANsat/SCAN_Toolbar/SCANtoolbar.cs
@@ -30,7 +30,7 @@ namespace SCANsat.SCAN_Toolbar
 		private IButton KSCButton;
 		private IButton ZoomButton;
 
-		public SCANtoolbar()
+		public void Awake() // SCANtoolbar()
 		{
 			if (!ToolbarManager.ToolbarAvailable)
 			{


### PR DESCRIPTION
Changed instantiator into an Awake because of the following error which is only visible in a debug build:

UnityException: get_dataPath is not allowed to be called from a MonoBehaviour constructor (or instance field initializer), call it in Awake or Start instead. Called from MonoBehaviour 'SCANtoolbar' on game object 'SCANtoolbar'.
See "Script Serialization" page in the Unity Manual for further details.
  at (wrapper managed-to-native) UnityEngine.Application.get_dataPath()
  at KSPUtil.get_ApplicationRootPath () [0x0001d] in <9d71e4043e394d78a6cf9193ad011698>:0
  at SCANsat.SCAN_Toolbar.SCANtoolbar..ctor () [0x00377] in <532e0c7735694646a2dba646ef08b593>:0