### PR TITLE
MechJeb 2.15

### DIFF
--- a/SCANmechjeb/SCANmechjeb.cs
+++ b/SCANmechjeb/SCANmechjeb.cs
@@ -214,8 +214,8 @@ namespace SCANmechjeb
 				return;
 			}
 
-			target = mjCore.target;
-
+			target = mjCore.Target;
+			
 			if (target == null)
 			{
 				SCANcontroller.controller.MechJebLoaded = false;
@@ -243,7 +243,7 @@ namespace SCANmechjeb
 
 				guidanceModule.UnlockCheck();
 
-				if (guidanceModule.hidden)
+				if (guidanceModule.Hidden)
 				{
 					SCANcontroller.controller.MechJebLoaded = false;
 					way = null;


### PR DESCRIPTION
```
[EXC 17:36:05.152] MissingFieldException: Field 'MuMech.MechJebCore.target' not found.
    SCANmechjeb.SCANmechjeb+<WaitForReady>d__13.MoveNext () (at <b67b1c892a3b4b18a985a5a0d486e6e3>:0)
    UnityEngine.SetupCoroutine.InvokeMoveNext (System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) (at <12e76cd50cc64cf19e759e981cb725af>:0)
    UnityEngine.DebugLogHandler:LogException(Exception, Object)
    ModuleManager.UnityLogHandle.InterceptLogHandler:LogException(Exception, Object)
    UnityEngine.MonoBehaviour:StartCoroutine(IEnumerator)
    SCANmechjeb.SCANmechjeb:Start()
```

https://github.com/MuMech/MechJeb2/commit/4bff46668dc1988b8b8663887a629a4d4eed0a45 hidden -> Hidden
https://github.com/MuMech/MechJeb2/commit/1bcbef069392dac7971d1d6a420edc51e7d561f7 target -> Target