### PR TITLE
Fixes #435 - White Maps in Sol

### DIFF
--- a/SCANsat/SCANcontroller.cs
+++ b/SCANsat/SCANcontroller.cs
@@ -1628,7 +1628,7 @@ namespace SCANsat
 				normalMapTextureName = "_NormalMap";
 				return;
 			}
-			else if (shaderName.Contains("ParallaxScaled"))
+			else if (shaderName.Contains("ParallaxScaled") || shaderName.Contains("HapkeScaled")) // HapkeScaled is the Sol shader which is also a Parallax-dependent instance
 			{
 				SCANparallaxContinued.LoadParallax(b, ref material);
 				useMaterialForColorMap = false;


### PR DESCRIPTION
Addresses Issue #435. Sol uses a shader named 'HapkeScaled', which bypasses the Parallax-Shader logic. In this name-based shader logic, the Hapke shader name needs to be added to the Parallax function logic.

Adding the Sol shader has no impacts to the existing Parallax-Scaled logic.

Original issue discussed here: https://github.com/RSS-Reborn/Sol-Configs/issues/1