### PR TITLE
Recreates Biome Colors when Biome Maps are Grayscale

### DIFF
--- a/SCANsat/SCAN_Map/SCANmapLegend.cs
+++ b/SCANsat/SCAN_Map/SCANmapLegend.cs
@@ -118,7 +118,7 @@ namespace SCANsat.SCAN_Map
 
 					if (stock && color)
 					{
-						pix[current] = biomes[i].mapColor;
+						pix[current] = SCANUtil.getBiomeDisplayColor(data.Body, i);
 					}
 					else if (color)
 					{
@@ -145,7 +145,7 @@ namespace SCANsat.SCAN_Map
 
 				if (SCAN_Settings_Config.Instance.BigMapStockBiomes && color)
 				{
-					pix[256 - backCount] = biomes[count - 1].mapColor;
+					pix[256 - backCount] = SCANUtil.getBiomeDisplayColor(data.Body, count - 1);
 				}
 				else if (color)
 				{

--- a/SCANsat/SCANutil.cs
+++ b/SCANsat/SCANutil.cs
@@ -534,6 +534,10 @@ namespace SCANsat
 
 		public static double[] cosLookUp = new double[180];
 		public static DictionaryValueList<CelestialBody, string> localizedBodyNames = new DictionaryValueList<CelestialBody, string>();
+		
+		/* Biome Map Encoding Data */
+		private static Dictionary<string, CBAttributeMapSO.MapAttribute[]> _scanBiomePaletteCache
+			= new Dictionary<string, CBAttributeMapSO.MapAttribute[]>();
 
 		internal static bool isCovered(double lon, double lat, SCANdata data, SCANtype type)
 		{
@@ -834,6 +838,48 @@ namespace SCANsat
 			return amount;
 		}
 
+		private static bool IsGrayscaleEncoded(CBAttributeMapSO.MapAttribute[] attrs)
+		{
+			foreach (var a in attrs)
+			{
+				if (a == null) continue;
+				if (Mathf.Abs(a.mapColor.g - 1f) > 0.01f) return false;
+				if (Mathf.Abs(a.mapColor.b - 1f) > 0.01f) return false;
+			}
+			return true;
+		}
+
+		private static CBAttributeMapSO.MapAttribute[] GetOrBuildPalette(CelestialBody body)
+		{
+			if (_scanBiomePaletteCache.TryGetValue(body.name, out var cached))
+				return cached;
+
+			var src = body.BiomeMap.Attributes;
+			if (!IsGrayscaleEncoded(src))
+			{
+				// Pack ships proper RGBA mapColors. Cache a null sentinel so we
+				// never re-detect, and never substitute.
+				_scanBiomePaletteCache[body.name] = null;
+				return null;
+			}
+
+			// Build replacements with categorical hues via golden-ratio HSV
+			var replacements = new CBAttributeMapSO.MapAttribute[src.Length];
+			for (int i = 0; i < src.Length; i++)
+			{
+				if (src[i] == null) continue;
+				var clone = new CBAttributeMapSO.MapAttribute
+				{
+					name = src[i].name,
+					value = src[i].value,
+					mapColor = Color.HSVToRGB((i * 0.61803398875f) % 1f, 1f, 1f)
+				};
+				replacements[i] = clone;
+			}
+			_scanBiomePaletteCache[body.name] = replacements;
+			return replacements;
+		}
+		
 		private static int getBiomeIndex(CelestialBody body, double lon, double lat)
 		{
 			if (body.BiomeMap == null)
@@ -850,6 +896,7 @@ namespace SCANsat
 			}
 
 			CBAttributeMapSO.MapAttribute att = body.BiomeMap.GetAtt(Mathf.Deg2Rad * lat, Mathf.Deg2Rad * lon);
+
 			for (int i = 0; i < body.BiomeMap.Attributes.Length; ++i)
 			{
 				if (body.BiomeMap.Attributes[i] == att)
@@ -882,6 +929,10 @@ namespace SCANsat
 			{
 				return null;
 			}
+			
+			var palette = GetOrBuildPalette(body);
+			if (palette != null && i < palette.Length && palette[i] != null)
+				return palette[i];
 
 			return body.BiomeMap.Attributes[i];
 		}
@@ -928,6 +979,19 @@ namespace SCANsat
 			}
 
 			sb.Append(string.IsNullOrEmpty(a.displayname) ? a.name : Localizer.Format(a.displayname));
+		}
+		internal static Color getBiomeDisplayColor(CelestialBody body, int idx)
+		{
+			if (body == null || body.BiomeMap == null) 
+				return Color.gray;
+			if (idx < 0 || idx >= body.BiomeMap.Attributes.Length) 
+				return Color.gray;
+
+			var palette = GetOrBuildPalette(body);
+			if (palette != null && palette[idx] != null)
+				return palette[idx].mapColor;
+
+			return body.BiomeMap.Attributes[idx].mapColor;
 		}
 
 		internal static int countBits(int i)


### PR DESCRIPTION
Issue not specifically addressed in the Issues log but is part of the broader Sol integration. Sol uses grayscale biome maps. Somewhere in the color conversions this creates a teal to white color range. Because the biome maps have no color data for SCANSat to leverage. I added logic that determines if the biome map is a grayscale image, and if so, the biome colors are arbitrarily recreated based on the total number of biomes and the color palette selected.

Issue originally discussed here with screenshot below: https://forum.kerbalspaceprogram.com/topic/229428-112x-sol-a-modern-recreation-of-our-home-system-at-real-quarter-and-stock-scale/page/4/

<img width="2242" height="699" alt="image" src="https://github.com/user-attachments/assets/ca022d97-98b1-4ad1-b55d-81a0995c8c1b" />