### PR TITLE
Fixes #433 - Recreates Z Data Based on Normal Map Encoding

### DIFF
--- a/SCANsat/SCAN_Map/SCANmap.cs
+++ b/SCANsat/SCAN_Map/SCANmap.cs
@@ -894,6 +894,7 @@ namespace SCANsat.SCAN_Map
 
 			Texture2D readableScaledSpaceMap = SCANcontroller.controller.getVisualMapTexture(body);
 			Texture2D readableScaledSpaceNormalMap = SCANcontroller.controller.getVisualMapNormalTexture(body);
+			SCANcontroller.NormalMapEncoding normalEncoding = SCANcontroller.controller.GetNormalMapEncoding(body);
 
 			for (int i = 0; i < map.width; i++)
 			{
@@ -1206,7 +1207,8 @@ namespace SCANsat.SCAN_Map
 
 									double opacity = 0.8;
 
-									double lumOver = readableScaledSpaceNormalMap.GetPixelBilinear(fLon, fLat).b;
+									double lumOver = GetZFromNormalMap(readableScaledSpaceNormalMap, normalEncoding,
+										fLon, fLat);
 									double lum = hslBase.L;
 
 									if (colorMap)
@@ -1475,6 +1477,29 @@ namespace SCANsat.SCAN_Map
 			}
 
 			return resourceCache[ilon, ilat];
+		}
+
+		private double GetZFromNormalMap(Texture2D normalMap, SCANcontroller.NormalMapEncoding encoding, float fLon, float fLat)
+		{
+			Color pixel = normalMap.GetPixelBilinear(fLon, fLat);
+			float nx, ny, nz = 0.0f;
+			switch (encoding)
+			{
+				case SCANcontroller.NormalMapEncoding.BC5:
+					// BC5: X in R, Y in G, B and A undefined post-blit
+					nx = pixel.r * 2f - 1f;
+					ny = pixel.g * 2f - 1f;
+					nz = Mathf.Sqrt(Mathf.Max(0f, 1f - nx * nx - ny * ny));
+					return (nz + 1f) * 0.5f; // BC5 Reconstructed Z
+				case SCANcontroller.NormalMapEncoding.DXT5NM:
+					// DXT5_NM: X in A, Y in G, R and B padded
+					nx = pixel.a * 2f - 1f;
+					ny = pixel.g * 2f - 1f;
+					nz = Mathf.Sqrt(Mathf.Max(0f, 1f - nx * nx - ny * ny));
+					return (nz + 1f) * 0.5f; // BC5 Reconstructed Z
+				default:
+					return pixel.b; // .b contains Z in RGA normal
+			}
 		}
 
 		#endregion

--- a/SCANsat/SCANcontroller.cs
+++ b/SCANsat/SCANcontroller.cs
@@ -158,6 +158,17 @@ namespace SCANsat
 		private Dictionary<CelestialBody, Texture2D> readableScaledSpaceNormalMaps = new Dictionary<CelestialBody, Texture2D>();
 		private CelestialBody bigMapBodyScaledSpace;
 		private CelestialBody zoomMapBodyScaledSpace;
+		
+		/* Normal Map Encoding Data */
+		public enum NormalMapEncoding
+		{
+			RGBA,	// RGB Normal: .b is Z
+			DXT5NM,	// X in A, Y in G, Z Reconstructed
+			BC5		// X in R, Y in G, Z Reconstructed
+		}
+
+		private Dictionary<CelestialBody, NormalMapEncoding> normalMapEncodings =
+			new Dictionary<CelestialBody, NormalMapEncoding>();
 
 		private SCAN_UI_MainMap _mainMap;
 		private SCAN_UI_Instruments _instruments;
@@ -1599,6 +1610,12 @@ namespace SCANsat
 		{
 
 		}
+		
+		public NormalMapEncoding GetNormalMapEncoding(CelestialBody b)
+		{
+			if (b == null) return NormalMapEncoding.RGBA;
+			return normalMapEncodings.TryGetValue(b, out var enc) ? enc : NormalMapEncoding.RGBA;
+		}
 
 		void GetVisualMapTexturesForBody(CelestialBody b, out Material material, out bool useMaterialForColorMap, out string colorMapTextureName, out string normalMapTextureName)
 		{
@@ -1633,7 +1650,7 @@ namespace SCANsat
 				SCANparallaxContinued.LoadParallax(b, ref material);
 				useMaterialForColorMap = false;
 				colorMapTextureName = "_ColorMap";
-				normalMapTextureName = null; // for whatever reason, the logic in ScANmap that uses the normal map doesn't work with parallax's normal maps
+				normalMapTextureName = "_BumpMap";
 				return;
 			}
 			else if (material.HasProperty("_MainTex"))
@@ -1655,7 +1672,7 @@ namespace SCANsat
 			}
 		}
 
-		void CacheScaledSpaceTexture(Dictionary<CelestialBody, Texture2D> cache, CelestialBody b, Material material, string textureName, bool useMaterial)
+		void CacheScaledSpaceTexture(Dictionary<CelestialBody, Texture2D> cache, CelestialBody b, Material material, string textureName, bool useMaterial, bool isNormalMap)
 		{
 			if (cache.GetValueOrDefault(b) == null && textureName != null)
 			{
@@ -1663,12 +1680,30 @@ namespace SCANsat
 				if (sourceTexture == null)
 				{
 					Log.Error($"GetTexture returned a null texture for body {b.name}, material {material.name} and texture name {textureName}");
+					return;
 				}
-				else
+
+				if (isNormalMap)
 				{
-					var colorMap = sourceTexture.isReadable ? sourceTexture : readableTexture(sourceTexture, useMaterial ? material : null);
-					cache.Add(b, colorMap);
+					NormalMapEncoding encoding;
+					switch (sourceTexture.format)
+					{
+						case TextureFormat.BC5:
+							encoding = NormalMapEncoding.BC5;
+							break;
+						case TextureFormat.DXT5:
+							encoding = NormalMapEncoding.DXT5NM;
+							break;
+						default:
+							encoding = NormalMapEncoding.RGBA;
+							break;
+					}
+
+					normalMapEncodings[b] = encoding;
 				}
+
+				var colorMap = sourceTexture.isReadable ? sourceTexture : readableTexture(sourceTexture, useMaterial ? material : null, isNormalMap);
+				cache.Add(b, colorMap);
 			}
 		}
 
@@ -1692,8 +1727,8 @@ namespace SCANsat
 			}
 			else
 			{
-				CacheScaledSpaceTexture(readableScaledSpaceMaps, b, material, colorMapTextureName, useMaterialForColorMap);
-				CacheScaledSpaceTexture(readableScaledSpaceNormalMaps, b, material, normalMapTextureName, false);
+				CacheScaledSpaceTexture(readableScaledSpaceMaps, b, material, colorMapTextureName, useMaterialForColorMap, false);
+				CacheScaledSpaceTexture(readableScaledSpaceNormalMaps, b, material, normalMapTextureName, false, true);
 			}
 
 			switch (s)
@@ -1753,10 +1788,11 @@ namespace SCANsat
 				GameObject.Destroy(readableScaledSpaceNormalMaps[b]);
 				readableScaledSpaceNormalMaps[b] = null;
 				readableScaledSpaceNormalMaps.Remove(b);
+				normalMapEncodings.Remove(b);
 			}
 		}
 
-		private Texture2D readableTexture(Texture tex, Material mat)
+		private Texture2D readableTexture(Texture tex, Material mat, bool isNormalMap = false)
 		{
 			if (tex == null)
 			{
@@ -1765,7 +1801,10 @@ namespace SCANsat
 
 			Texture2D readable = new Texture2D(tex.width, tex.height);
 
-			var rt = RenderTexture.GetTemporary(tex.width, tex.height, 0, RenderTextureFormat.ARGB32, RenderTextureReadWrite.sRGB, 1);
+			var readWrite = isNormalMap
+				? RenderTextureReadWrite.Linear
+				: RenderTextureReadWrite.sRGB;
+			var rt = RenderTexture.GetTemporary(tex.width, tex.height, 0, RenderTextureFormat.ARGB32, readWrite, 1);
 
 			if (mat != null)
 			{


### PR DESCRIPTION
Addresses #433. Logic detects which type of normal map has been provided (e.g., DXT5) and recreates the Z component from the Unity Color class. Each file type stores Z information in a different way (or not), and it can be accessed directly or recreated based on how the information is encoded in the Unity Color class.

Issue #433 has been cited as the source of the white visual maps when using Sol (#435); however, the issues are distinct. The white maps in Sol are a shader name issue and a default to the "white" map color when nothing else triggers. (See #455). Likewise, this is also not the source of the teal/white biome colors that occur when a map is grayscale (See #452 & #456).