### PR TITLE
Fixes #439 With Backward Compatibility

### DIFF
--- a/SCANmechjeb/SCANmechjeb.cs
+++ b/SCANmechjeb/SCANmechjeb.cs
@@ -35,6 +35,45 @@ namespace SCANmechjeb
 		private SCANdata data;
 		private Vector2d coords = new Vector2d();
 		private bool shutdown, mjOnboard, mjTechTreeLocked;
+		
+		#region Helpers
+
+		/// <summary>
+		/// Reflectively fetches MechJebCore's target controller, tolerating the
+		/// 'Target'/'target' field rename across MechJeb versions. Returns null
+		/// (and logs) if the field can't be resolved under any known name.
+		/// </summary>
+		private static MechJebModuleTargetController GetMJCoreTarget(MechJebCore mjc)
+		{
+			var t = mjc.GetType();
+			var field = t.GetField("Target") ?? t.GetField("target");
+			if (field == null)
+			{
+				KSPBuildTools.Log.Message(
+					"MechJebCore 'target' field could not be found under any known name; MechJeb support broken.");
+			}
+
+			return field?.GetValue(mjc) as MechJebModuleTargetController;
+		}
+
+		/// <summary>
+		/// Reflectively reads the guidance module's hidden flag, tolerating the
+		/// 'Hidden'/'hidden' field rename across MechJeb versions. Returns null
+		/// (and logs) if the field can't be resolved under any known name.
+		/// </summary>
+		private static bool? IsMJGuidanceModuleHidden(DisplayModule gm)
+		{
+			var t = gm.GetType();
+			var field = t.GetField("Hidden") ?? t.GetField("hidden");
+			if (field == null)
+			{
+				KSPBuildTools.Log.Message(
+					"MechJebGuidanceModule 'hidden' field could not be found under any known name; MechJeb support broken.");
+			}
+			return field?.GetValue(gm) as bool?;
+		}
+		
+		#endregion
 
 		private void Start()
 		{
@@ -227,8 +266,8 @@ namespace SCANmechjeb
 				return;
 			}
 
-			target = mjCore.target;
-
+			target = GetMJCoreTarget(mjCore);
+			
 			if (target == null)
 			{
 				SCANcontroller.controller.MechJebLoaded = false;
@@ -256,7 +295,8 @@ namespace SCANmechjeb
 
 				guidanceModule.UnlockCheck();
 
-				if (guidanceModule.hidden)
+				var hidden = IsMJGuidanceModuleHidden(guidanceModule);
+				if (hidden ?? true) // Defaults to a hidden state if the field cannot be found
 				{
 					SCANcontroller.controller.MechJebLoaded = false;
 					way = null;


### PR DESCRIPTION
PR #441 fixes #439 by changing 'target' -> 'Target' & 'hidden' -> 'Hidden' to support MJ 2.15 and later.

This is an alternative approach mentioned by @JonnyOThan in the #439 discussion that uses reflection to support both pre-2.15 and 2.15+ MechJeb. If neither name resolves, the failure logged.